### PR TITLE
More fixes

### DIFF
--- a/PureStoragePlugin.pm
+++ b/PureStoragePlugin.pm
@@ -32,7 +32,7 @@ $Data::Dumper::Indent = 1;    # Outputs everything in one line
 $Data::Dumper::Useqq  = 1;    # Uses quotes for strings
 
 my $purestorage_wwn_prefix = "624a9370";
-my $default_hgsuffix = "pve";
+my $default_hgsuffix = "";
 
 my $DEBUG = 0;
 


### PR DESCRIPTION
Changed the default value of  `hgsuffix` to be empty string. This makes is truly optional (see the [issue](https://github.com/amulet1/pve-purestorage-plugin/issues/5) for more details).

PVE Storage library does not deactivate disks when they are detached (see [ticket](https://bugzilla.proxmox.com/show_bug.cgi?id=6085)). As a result rename_volume() maybe called while the (unused) disk is still mapped.  Moving such disk to another VM without unmapping leaves dormant entries in `/dev`. This PR fixes the issue, but a better fix would be if PVE team makes changes on their end.
