### PR TITLE
Add support for "podname" and "vnprefix" parameters (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ purestorage: <storage_id>
 | nodes | (`optional`) A comma-separated list of Proxmox node names. Use this parameter to limit the plugin to specific nodes in your cluster. If omitted, the storage is available to all nodes. |
 | address | The URL or IP address of the Pure Storage API endpoint. Ensure that the Proxmox VE nodes can reach this address over the network. |
 | token | The API token used for authentication with the Pure Storage array. This token must have sufficient permissions to create and manage volumes. |
-| vgname | The name of the volume group where new virtual disks will be created. This should match the configuration on your Pure Storage array. |
+| vgname | (`optional`, conflicts with `podname`) The volume group name where virtual disks will be stored. This should match the configuration on your Pure Storage array. |
+| podname | (`optional`, conflicts with `vgname`) The pod name where virtual disks will be stored. This should match the configuration on your Pure Storage array. |
+| vnprefix | (`optional`) The prefix to prepend to name of virtual disks. |
 | hgsuffix | (`optional`) A suffix that is appended to the hostname when the plugin interacts with the Pure Storage array. This can help differentiate hosts if necessary. |
 | content | Specifies the types of content that can be stored. For virtual machine disk images, use images. |
 


### PR DESCRIPTION
This is the implementation I suggested earlier with minor changes.

The `podname` value (mutually exclusive with `vgname`) specifies PureStorage pod name.

The `vnprefix` value is an optional prefix to prepend to volume names.

The `vnprefix` can be used in combination with `podname` or `vgname`.

Examples of volume name "vm-100-disk-0" mapping to PureStorage:
 `podname mypod`                  => `mypod::vm-100-disk-0`
    (same as `vnprefix mypod::`)

 `vgname mypve`                   => `mypve/vm-100-disk-0`
    (same as `vnprefix mypve/`)

 `podname mypod`, `vnprefix dev-` => `mypod::dev-vm-100-disk-0`
    (same as `vnprefix mypod::dev-`)

 `vgname mypve`, `vnprefix dev-`  => `mypve/dev-vm-100-disk-0`
    (same as `vnprefix mypve/dev-`)

Also:
 * Made `vgname` parameter optional
 * Moved array address parameters check to `purestorage_api_request()`
 * Removed volume info caching (#15), eliminated `purestorage_volume_info()`
 * Modified `purestorage_list_volumes()` to return only disk names we recognize [ `$vmid = undef` case ]
 * Use substr() instead of regex to strip volume name prefix in `purestorage_get_volumes()`
 * Show PVE volume names in "Info ::" messages
 * Added description of new parameters to README.md