### PR TITLE
Cleanup after 'multipathd remove map'

### DIFF
--- a/PureStoragePlugin.pm
+++ b/PureStoragePlugin.pm
@@ -128,7 +128,8 @@ my $cmd = {
   #  fuser      => '/usr/bin/fuser',
   multipath  => '/sbin/multipath',
   multipathd => '/sbin/multipathd',
-  blockdev   => '/usr/sbin/blockdev'
+  blockdev   => '/usr/sbin/blockdev',
+  sed        => '/usr/bin/sed'
 };
 
 sub exec_command {
@@ -1082,6 +1083,9 @@ sub unmap_volume {
 
     # remove the link
     exec_command( [ 'multipathd', 'remove', 'map', $wwid ] );
+
+    # remove wwid from map file
+    exec_command( [ $cmd->{ sed }, '-i', "/$wwid/d", '/etc/multipath/wwids' ], 0 );
   } else {
     print "Debug :: Device \"$wwid\" is not a multipath device. Skipping multipath removal.\n" if $DEBUG;
   }

--- a/PureStoragePlugin.pm
+++ b/PureStoragePlugin.pm
@@ -1085,7 +1085,7 @@ sub unmap_volume {
     exec_command( [ 'multipathd', 'remove', 'map', $wwid ] );
 
     # remove wwid from map file
-    exec_command( [ $cmd->{ sed }, '-i', "/$wwid/d", '/etc/multipath/wwids' ], 0 );
+    exec_command( [ 'sed', '-i', "/$wwid/d", '/etc/multipath/wwids' ], 0 );
   } else {
     print "Debug :: Device \"$wwid\" is not a multipath device. Skipping multipath removal.\n" if $DEBUG;
   }


### PR DESCRIPTION
Since the switch to multipathd, the 'multipathd remove map' wont cleanup the wwids file.