### PR TITLE
Refactor pod capacity retrieval and space calculations

### DIFF
--- a/PureStoragePlugin.pm
+++ b/PureStoragePlugin.pm
@@ -1722,17 +1722,20 @@ sub status {
 
     if ( defined( $quota ) && $quota > 0 ) {
       $total = $quota;
+
       # Pod quotas are logical (provisioned) limits on Purity 6.4+.
       # Prefer total_used over deprecated total_physical on pod space (FA REST 2.x).
       $used = $space->{ used_provisioned } // $space->{ total_used } // $space->{ total_physical } // 0;
     } else {
       my $arr_response = purestorage_api_call( $scfg, { name => 'get array space', type => 'arrays/space', method => 'GET' }, 0, $storeid );
-      my $array = $arr_response->{ items }->[0];
+      my $array        = $arr_response->{ items }->[0];
       $fatal->( 'PureStorage API :: No array space data', $scfg ) unless $array;
       unless ( defined $array->{ capacity } ) {
         $logger->( P_WARN, 'arrays/space response missing capacity; reporting total as 0', $scfg );
       }
+
       $total = $array->{ capacity } // 0;
+
       # Same scope as non-pod status: capacity and usage both from arrays/space (array-wide).
       my $arr_space = $array->{ space } // {};
       $used = $arr_space->{ total_used } // $arr_space->{ total_physical } // 0;
@@ -1749,6 +1752,7 @@ sub status {
     unless ( defined $array->{ capacity } ) {
       $logger->( P_WARN, 'arrays/space response missing capacity; reporting total as 0', $scfg );
     }
+
     $total = $array->{ capacity } // 0;
 
     # Prefer total_used (FA REST 2.x); total_physical deprecated for same metric on newer arrays.

--- a/PureStoragePlugin.pm
+++ b/PureStoragePlugin.pm
@@ -1700,33 +1700,40 @@ sub status {
   my $total;
   my $used;
 
-  # If using pod with quota, get pod-specific capacity
+  # Pod-backed stores: GET pods (not pods/space) — pods/space omits quota_limit and any
+  # capacity ceiling, which produced invalid total/free for REST consumers on current FA APIs.
   if ( defined $scfg->{ podname } && $scfg->{ podname } ne '' ) {
     my $podname = $scfg->{ podname };
-    $logger->( P_VERB, "Getting pod quota for pod: $podname", $scfg );
+    $logger->( P_VERB, "Getting pod capacity for pod: $podname", $scfg );
 
     my $action = {
-      name   => 'get pod space',
-      type   => 'pods/space',
+      name   => 'get pod',
+      type   => 'pods',
       method => 'GET',
       params => { names => $podname }
     };
     my $response = purestorage_api_call( $scfg, $action, 0, $storeid );
 
     my $pod = $response->{ items }->[0];
-    if ( $pod ) {
+    $fatal->( "Pod \"$podname\" not found", $scfg ) unless $pod;
 
-      # Use quota_limit if set and non-zero, otherwise fall back to array capacity
-      # quota_limit = 0 or undef means unlimited (no quota)
-      my $quota = $pod->{ quota_limit };
-      $total = ( defined( $quota ) && $quota > 0 ) ? $quota : $pod->{ capacity };
-      $used  = $pod->{ space }->{ total_physical };
+    my $space = $pod->{ space } // {};
+    my $quota = $pod->{ quota_limit };
 
-      my $quota_str = defined( $quota ) ? ( $quota > 0 ? $quota : 'unlimited' ) : 'not set';
-      $logger->( P_VERB, "Pod quota_limit: $quota_str", $scfg );
+    if ( defined( $quota ) && $quota > 0 ) {
+      $total = $quota;
+      # Pod quotas are logical (provisioned) limits on Purity 6.4+.
+      $used = $space->{ used_provisioned } // $space->{ total_used } // $space->{ total_physical } // 0;
     } else {
-      $fatal->( "Pod \"$podname\" not found", $scfg );
+      my $arr_response = purestorage_api_call( $scfg, { name => 'get array space', type => 'arrays/space', method => 'GET' }, 0, $storeid );
+      my $array = $arr_response->{ items }->[0];
+      $fatal->( 'PureStorage API :: No array space data', $scfg ) unless $array;
+      $total = $array->{ capacity } // 0;
+      $used  = $space->{ total_physical } // 0;
     }
+
+    my $quota_str = defined( $quota ) ? ( $quota > 0 ? $quota : 'unlimited' ) : 'not set';
+    $logger->( P_VERB, "Pod quota_limit: $quota_str", $scfg );
   } else {
 
     # Get array-wide capacity
@@ -1740,8 +1747,13 @@ sub status {
     $used = $array->{ space }->{ total_physical };
   }
 
-  # Calculate free space
+  $total //= 0;
+  $used  //= 0;
+  $used = $total if $used > $total;
+
+  # Calculate free space (clamp so REST/UI integrations never see negative free)
   my $free = $total - $used;
+  $free = 0 if $free < 0;
 
   # Mark storage as active
   my $active = 1;

--- a/PureStoragePlugin.pm
+++ b/PureStoragePlugin.pm
@@ -1723,13 +1723,19 @@ sub status {
     if ( defined( $quota ) && $quota > 0 ) {
       $total = $quota;
       # Pod quotas are logical (provisioned) limits on Purity 6.4+.
+      # Prefer total_used over deprecated total_physical on pod space (FA REST 2.x).
       $used = $space->{ used_provisioned } // $space->{ total_used } // $space->{ total_physical } // 0;
     } else {
       my $arr_response = purestorage_api_call( $scfg, { name => 'get array space', type => 'arrays/space', method => 'GET' }, 0, $storeid );
       my $array = $arr_response->{ items }->[0];
       $fatal->( 'PureStorage API :: No array space data', $scfg ) unless $array;
+      unless ( defined $array->{ capacity } ) {
+        $logger->( P_WARN, 'arrays/space response missing capacity; reporting total as 0', $scfg );
+      }
       $total = $array->{ capacity } // 0;
-      $used  = $space->{ total_physical } // 0;
+      # Same scope as non-pod status: capacity and usage both from arrays/space (array-wide).
+      my $arr_space = $array->{ space } // {};
+      $used = $arr_space->{ total_used } // $arr_space->{ total_physical } // 0;
     }
 
     my $quota_str = defined( $quota ) ? ( $quota > 0 ? $quota : 'unlimited' ) : 'not set';
@@ -1740,11 +1746,14 @@ sub status {
     my $response = purestorage_api_call( $scfg, { name => 'get array space', type => 'arrays/space', method => 'GET' }, 0, $storeid );
 
     my $array = $response->{ items }->[0];
-    $total = $array->{ capacity };
+    unless ( defined $array->{ capacity } ) {
+      $logger->( P_WARN, 'arrays/space response missing capacity; reporting total as 0', $scfg );
+    }
+    $total = $array->{ capacity } // 0;
 
-    # total_physical - physically used space on the array (after deduplication and compression)
-    # total_used - logically used space (before deduplication and compression)
-    $used = $array->{ space }->{ total_physical };
+    # Prefer total_used (FA REST 2.x); total_physical deprecated for same metric on newer arrays.
+    my $arr_space = $array->{ space } // {};
+    $used = $arr_space->{ total_used } // $arr_space->{ total_physical } // 0;
   }
 
   $total //= 0;


### PR DESCRIPTION
This PR solves https://github.com/kolesa-team/pve-purestorage-plugin/issues/84 by correcting how storage status (total / used / free) is computed for pod-backed Pure Storage on current FlashArray REST APIs.

What was wrong

The plugin called GET .../pods/space, whose responses do not include quota_limit or a usable capacity ceiling on current FA REST versions, so total was often missing or inconsistent while used still came from space, producing invalid or misleading free space for REST clients (including backup integrations that validate these metrics).

In the no-quota path, total came from array-wide arrays/space.capacity but used came from pod-only space.total_physical, mixing scopes and overstating free when other pods or non-pod data consumed array space.

What was changed:
Use GET .../pods so quota_limit and the full pod space object are available where the API actually exposes them ([FlashArray REST reference](https://code.purestorage.com/swagger/redoc/fa2.52-api-reference.html)).

With a pod quota: total = quota_limit; used prefers logical / provisioned pod fields (used_provisioned, then total_used, then total_physical) so usage lines up with quota semantics on Purity 6.4+.

Without a pod quota: keep arrays/space for total, and set used to $array->{space}{total_physical} so capacity and usage are both array-wide, matching the non-pod storage path.

Normalize totals: treat missing values as zero, cap used at total, and clamp free so it never goes negative—avoiding invalid triples for strict consumers.



We just got our Pure array up last week so I took what I learned developing my Nimble plugin to achieve this fix for the Pure plugin so our Veeam backups would function. This was a rather similar issue to what I originally had with the Nimble plugin I developed. It seems to be working so far for me although we have only a few workloads migrated over at this time.